### PR TITLE
WIP: Psm normalization - NoMerge

### DIFF
--- a/src/join-5-auth.sol
+++ b/src/join-5-auth.sol
@@ -65,18 +65,18 @@ contract AuthGemJoin5 is LibNote {
         require(y == 0 || (z = x * y) / y == x, "GemJoin5/overflow");
     }
 
-    function join(address urn, uint256 wad, address _msgSender) external note auth {
+    function join(address guy, uint256 wad) external note auth {
         require(live == 1, "GemJoin5/not-live");
         uint256 wad18 = mul(wad, 10 ** (18 - dec));
         require(int256(wad18) >= 0, "GemJoin5/overflow");
-        vat.slip(ilk, urn, int256(wad18));
-        require(gem.transferFrom(_msgSender, address(this), wad), "GemJoin5/failed-transfer");
+        vat.slip(ilk, guy, int256(wad18));
+        require(gem.transferFrom(guy, address(this), wad), "GemJoin5/join-failed-transfer");
     }
 
     function exit(address guy, uint256 wad) external note {
         uint256 wad18 = mul(wad, 10 ** (18 - dec));
         require(int256(wad18) >= 0, "GemJoin5/overflow");
         vat.slip(ilk, msg.sender, -int256(wad18));
-        require(gem.transfer(guy, wad), "GemJoin5/failed-transfer");
+        require(gem.transfer(guy, wad), "GemJoin5/exit-failed-transfer");
     }
 }

--- a/src/psm.sol
+++ b/src/psm.sol
@@ -1,16 +1,10 @@
 pragma solidity ^0.6.7;
 
 import { DaiJoinAbstract } from "dss-interfaces/dss/DaiJoinAbstract.sol";
+import { AuthGemJoinAbstract } from "dss-interfaces/dss/AuthGemJoinAbstract.sol";
 import { DaiAbstract } from "dss-interfaces/dss/DaiAbstract.sol";
 import { VatAbstract } from "dss-interfaces/dss/VatAbstract.sol";
-
-interface AuthGemJoinAbstract {
-    function dec() external view returns (uint256);
-    function vat() external view returns (address);
-    function ilk() external view returns (bytes32);
-    function join(address, uint256, address) external;
-    function exit(address, uint256) external;
-}
+import { GemAbstract } from "dss-interfaces/ERC/GemAbstract.sol";
 
 // Peg Stability Module
 // Allows anyone to go between Dai and the Gem by pooling the liquidity
@@ -24,37 +18,42 @@ contract DssPsm {
     function deny(address usr) external auth { wards[usr] = 0; emit Deny(usr); }
     modifier auth { require(wards[msg.sender] == 1); _; }
 
-    VatAbstract immutable public vat;
+    VatAbstract         immutable public vat;
+    address             immutable public vow;
+    bytes32             immutable public ilk;
     AuthGemJoinAbstract immutable public gemJoin;
-    DaiAbstract immutable public dai;
-    DaiJoinAbstract immutable public daiJoin;
-    bytes32 immutable public ilk;
-    address immutable public vow;
+    DaiJoinAbstract     immutable public daiJoin;
+    GemAbstract         immutable public token;
+    DaiAbstract         immutable public dai;
 
-    uint256 immutable internal to18ConversionFactor;
+    uint256             immutable internal to18ConversionFactor;
 
-    uint256 public tin;         // toll in [wad]
-    uint256 public tout;        // toll out [wad]
+    uint256             public tin;         // toll in [wad]
+    uint256             public tout;        // toll out [wad]
 
     // --- Events ---
     event Rely(address indexed usr);
     event Deny(address indexed usr);
     event File(bytes32 indexed what, uint256 data);
-    event SellGem(address indexed owner, uint256 value, uint256 fee);
-    event BuyGem(address indexed owner, uint256 value, uint256 fee);
+    event Sell(address indexed owner, uint256 value, uint256 fee);
+    event Buy(address indexed owner, uint256 value, uint256 fee);
 
     // --- Init ---
     constructor(address gemJoin_, address daiJoin_, address vow_) public {
         wards[msg.sender] = 1;
         emit Rely(msg.sender);
         AuthGemJoinAbstract gemJoin__ = gemJoin = AuthGemJoinAbstract(gemJoin_);
-        DaiJoinAbstract daiJoin__ = daiJoin = DaiJoinAbstract(daiJoin_);
-        VatAbstract vat__ = vat = VatAbstract(address(gemJoin__.vat()));
-        DaiAbstract dai__ = dai = DaiAbstract(address(daiJoin__.dai()));
+        DaiJoinAbstract daiJoin__     = daiJoin = DaiJoinAbstract(daiJoin_);
+        VatAbstract vat__             = vat     = VatAbstract(address(gemJoin__.vat()));
+        DaiAbstract dai__             = dai     = DaiAbstract(address(daiJoin__.dai()));
+        GemAbstract token__           = token   = GemAbstract(address(gemJoin__.gem()));
         ilk = gemJoin__.ilk();
         vow = vow_;
         to18ConversionFactor = 10 ** (18 - gemJoin__.dec());
-        dai__.approve(daiJoin_, uint256(-1));
+
+        require(dai__.approve(daiJoin_, uint256(-1)),   "DssPsm/dai-failed-approve");
+        require(token__.approve(gemJoin_, uint256(-1)), "DssPsm/token-failed-approve");
+
         vat__.hope(daiJoin_);
     }
 
@@ -73,8 +72,14 @@ contract DssPsm {
 
     // --- Administration ---
     function file(bytes32 what, uint256 data) external auth {
-        if (what == "tin") tin = data;
-        else if (what == "tout") tout = data;
+        if (what == "tin") {
+            require(data < WAD , "DssPsm/more-100-percent");
+            tin = data;
+        }
+        else if (what == "tout") {
+            require(data < WAD , "DssPsm/more-100-percent");
+            tout = data;
+        }
         else revert("DssPsm/file-unrecognized-param");
 
         emit File(what, data);
@@ -90,29 +95,36 @@ contract DssPsm {
     }
 
     // --- Primary Functions ---
-    function sellGem(address usr, uint256 gemAmt) external {
+    function sell(address usr, uint256 gemAmt) external {
         uint256 gemAmt18 = mul(gemAmt, to18ConversionFactor);
         uint256 fee = mul(gemAmt18, tin) / WAD;
         uint256 daiAmt = sub(gemAmt18, fee);
-        gemJoin.join(address(this), gemAmt, msg.sender);
+
+        emit Sell(usr, gemAmt, fee);
+
+        require(token.transferFrom(msg.sender, address(this), gemAmt), "DssPsm/failed-sell-transfer");
+
+        gemJoin.join(address(this), gemAmt);
         vat.frob(ilk, address(this), address(this), address(this), int256(gemAmt18), int256(gemAmt18));
-        vat.move(address(this), vow, mul(fee, RAY));
         daiJoin.exit(usr, daiAmt);
 
-        emit SellGem(usr, gemAmt, fee);
+        vat.move(address(this), vow, mul(fee, RAY));
     }
 
-    function buyGem(address usr, uint256 gemAmt) external {
+    function buy(address usr, uint256 gemAmt) external {
         uint256 gemAmt18 = mul(gemAmt, to18ConversionFactor);
         uint256 fee = mul(gemAmt18, tout) / WAD;
         uint256 daiAmt = add(gemAmt18, fee);
-        require(dai.transferFrom(msg.sender, address(this), daiAmt), "DssPsm/failed-transfer");
+
+        emit Buy(usr, gemAmt, fee);
+
+        require(dai.transferFrom(msg.sender, address(this), daiAmt), "DssPsm/failed-buy-transfer");
+
         daiJoin.join(address(this), daiAmt);
         vat.frob(ilk, address(this), address(this), address(this), -int256(gemAmt18), -int256(gemAmt18));
         gemJoin.exit(usr, gemAmt);
-        vat.move(address(this), vow, mul(fee, RAY));
 
-        emit BuyGem(usr, gemAmt, fee);
+        vat.move(address(this), vow, mul(fee, RAY));
     }
 
 }

--- a/src/psm.t.sol
+++ b/src/psm.t.sol
@@ -54,20 +54,19 @@ contract User {
     AuthGemJoin5 public gemJoin;
     DssPsm public psm;
 
-    constructor(Dai dai_, AuthGemJoin5 gemJoin_, DssPsm psm_) public {
+    constructor(Dai dai_, DssPsm psm_) public {
         dai = dai_;
-        gemJoin = gemJoin_;
         psm = psm_;
     }
 
-    function sellGem(uint256 wad) public {
-        DSToken(address(gemJoin.gem())).approve(address(gemJoin));
-        psm.sellGem(address(this), wad);
+    function sell(uint256 wad) public {
+        DSToken(address(psm.token())).approve(address(psm));
+        psm.sell(address(this), wad);
     }
 
-    function buyGem(uint256 wad) public {
+    function buy(uint256 wad) public {
         dai.approve(address(psm), uint256(-1));
-        psm.buyGem(address(this), wad);
+        psm.buy(address(this), wad);
     }
 
 }
@@ -112,7 +111,6 @@ contract DssPsmTest is DSTest {
         me = address(this);
 
         vat = new TestVat();
-        vat = vat;
 
         spot = new Spotter(address(vat));
         vat.rely(address(spot));
@@ -147,15 +145,15 @@ contract DssPsmTest is DSTest {
         vat.file("Line",      rad(1000 ether));
     }
 
-    function test_sellGem_no_fee() public {
+    function test_sell_no_fee() public {
         assertEq(usdx.balanceOf(me), 1000 * USDX_WAD);
         assertEq(vat.gem(ilk, me), 0);
         assertEq(vat.dai(me), 0);
         assertEq(dai.balanceOf(me), 0);
         assertEq(vow.Joy(), 0);
 
-        usdx.approve(address(gemA));
-        psmA.sellGem(me, 100 * USDX_WAD);
+        usdx.approve(address(psmA));
+        psmA.sell(me, 100 * USDX_WAD);
 
         assertEq(usdx.balanceOf(me), 900 * USDX_WAD);
         assertEq(vat.gem(ilk, me), 0);
@@ -170,7 +168,7 @@ contract DssPsmTest is DSTest {
         assertEq(artpsm, 100 ether);
     }
 
-    function test_sellGem_fee() public {
+    function test_sell_fee() public {
         psmA.file("tin", TOLL_ONE_PCT);
 
         assertEq(usdx.balanceOf(me), 1000 * USDX_WAD);
@@ -179,8 +177,8 @@ contract DssPsmTest is DSTest {
         assertEq(dai.balanceOf(me), 0);
         assertEq(vow.Joy(), 0);
 
-        usdx.approve(address(gemA));
-        psmA.sellGem(me, 100 * USDX_WAD);
+        usdx.approve(address(psmA));
+        psmA.sell(me, 100 * USDX_WAD);
 
         assertEq(usdx.balanceOf(me), 900 * USDX_WAD);
         assertEq(vat.gem(ilk, me), 0);
@@ -190,10 +188,10 @@ contract DssPsmTest is DSTest {
     }
 
     function test_swap_both_no_fee() public {
-        usdx.approve(address(gemA));
-        psmA.sellGem(me, 100 * USDX_WAD);
+        usdx.approve(address(psmA));
+        psmA.sell(me, 100 * USDX_WAD);
         dai.approve(address(psmA), 40 ether);
-        psmA.buyGem(me, 40 * USDX_WAD);
+        psmA.buy(me, 40 * USDX_WAD);
 
         assertEq(usdx.balanceOf(me), 940 * USDX_WAD);
         assertEq(vat.gem(ilk, me), 0);
@@ -209,8 +207,8 @@ contract DssPsmTest is DSTest {
         psmA.file("tin", 5 * TOLL_ONE_PCT);
         psmA.file("tout", 10 * TOLL_ONE_PCT);
 
-        usdx.approve(address(gemA));
-        psmA.sellGem(me, 100 * USDX_WAD);
+        usdx.approve(address(psmA));
+        psmA.sell(me, 100 * USDX_WAD);
 
         assertEq(usdx.balanceOf(me), 900 * USDX_WAD);
         assertEq(dai.balanceOf(me), 95 ether);
@@ -220,7 +218,7 @@ contract DssPsmTest is DSTest {
         assertEq(art1, 100 ether);
 
         dai.approve(address(psmA), 44 ether);
-        psmA.buyGem(me, 40 * USDX_WAD);
+        psmA.buy(me, 40 * USDX_WAD);
 
         assertEq(usdx.balanceOf(me), 940 * USDX_WAD);
         assertEq(dai.balanceOf(me), 51 ether);
@@ -231,16 +229,16 @@ contract DssPsmTest is DSTest {
     }
 
     function test_swap_both_other() public {
-        usdx.approve(address(gemA));
-        psmA.sellGem(me, 100 * USDX_WAD);
+        usdx.approve(address(psmA));
+        psmA.sell(me, 100 * USDX_WAD);
 
         assertEq(usdx.balanceOf(me), 900 * USDX_WAD);
         assertEq(dai.balanceOf(me), 100 ether);
         assertEq(vow.Joy(), rad(0 ether));
 
-        User someUser = new User(dai, gemA, psmA);
+        User someUser = new User(dai, psmA);
         dai.mint(address(someUser), 45 ether);
-        someUser.buyGem(40 * USDX_WAD);
+        someUser.buy(40 * USDX_WAD);
 
         assertEq(usdx.balanceOf(me), 900 * USDX_WAD);
         assertEq(usdx.balanceOf(address(someUser)), 40 * USDX_WAD);
@@ -259,9 +257,9 @@ contract DssPsmTest is DSTest {
     function test_swap_both_other_small_fee() public {
         psmA.file("tin", 1);
 
-        User user1 = new User(dai, gemA, psmA);
+        User user1 = new User(dai, psmA);
         usdx.transfer(address(user1), 40 * USDX_WAD);
-        user1.sellGem(40 * USDX_WAD);
+        user1.sell(40 * USDX_WAD);
 
         assertEq(usdx.balanceOf(address(user1)), 0 * USDX_WAD);
         assertEq(dai.balanceOf(address(user1)), 40 ether - 40);
@@ -270,7 +268,7 @@ contract DssPsmTest is DSTest {
         assertEq(ink1, 40 ether);
         assertEq(art1, 40 ether);
 
-        user1.buyGem(40 * USDX_WAD - 1);
+        user1.buy(40 * USDX_WAD - 1);
 
         assertEq(usdx.balanceOf(address(user1)), 40 * USDX_WAD - 1);
         assertEq(dai.balanceOf(address(user1)), 999999999960);
@@ -280,46 +278,46 @@ contract DssPsmTest is DSTest {
         assertEq(art2, 1 * 10 ** 12);
     }
 
-    function testFail_sellGem_insufficient_gem() public {
-        User user1 = new User(dai, gemA, psmA);
-        user1.sellGem(40 * USDX_WAD);
+    function testFail_sell_insufficient_gem() public {
+        User user1 = new User(dai, psmA);
+        user1.sell(40 * USDX_WAD);
     }
 
     function testFail_swap_both_small_fee_insufficient_dai() public {
         psmA.file("tin", 1);        // Very small fee pushes you over the edge
 
-        User user1 = new User(dai, gemA, psmA);
+        User user1 = new User(dai, psmA);
         usdx.transfer(address(user1), 40 * USDX_WAD);
-        user1.sellGem(40 * USDX_WAD);
-        user1.buyGem(40 * USDX_WAD);
+        user1.sell(40 * USDX_WAD);
+        user1.buy(40 * USDX_WAD);
     }
 
-    function testFail_sellGem_over_line() public {
+    function testFail_sell_over_line() public {
         usdx.mint(1000 * USDX_WAD);
-        usdx.approve(address(gemA));
-        psmA.buyGem(me, 2000 * USDX_WAD);
+        usdx.approve(address(psmA));
+        psmA.buy(me, 2000 * USDX_WAD);
     }
 
     function testFail_two_users_insufficient_dai() public {
-        User user1 = new User(dai, gemA, psmA);
+        User user1 = new User(dai, psmA);
         usdx.transfer(address(user1), 40 * USDX_WAD);
-        user1.sellGem(40 * USDX_WAD);
+        user1.sell(40 * USDX_WAD);
 
-        User user2 = new User(dai, gemA, psmA);
+        User user2 = new User(dai, psmA);
         dai.mint(address(user2), 39 ether);
-        user2.buyGem(40 * USDX_WAD);
+        user2.buy(40 * USDX_WAD);
     }
 
     function test_swap_both_zero() public {
         usdx.approve(address(gemA), uint(-1));
-        psmA.sellGem(me, 0);
+        psmA.sell(me, 0);
         dai.approve(address(psmA), uint(-1));
-        psmA.buyGem(me, 0);
+        psmA.buy(me, 0);
     }
 
     function testFail_direct_deposit() public {
         usdx.approve(address(gemA), uint(-1));
-        gemA.join(me, 10 * USDX_WAD, me);
+        gemA.join(me, 10 * USDX_WAD);
     }
     
 }


### PR DESCRIPTION
Psm
    - Remove low layer dependency.
    - Use AuthGemJoinAbstract from dss-interface
    - Add token variable
    - Rename SellGem to Sell
    - Rename BuyGem to Buy
    - Formatting
    - Check the approve method
    - Add token approve to send to low layer dependency
    - Check tin and tout input
    - Remove exotic AuthGemJoin call
    - Move emit call before external call.
    - Add symmetric process method call for Buy and Sell.
    
    Update test accordingly.
    
    Join
    - Remove exotic auth join use AuthGemJoinAbstract interface.